### PR TITLE
update cadc-java and cadc-tomcat to fc37

### DIFF
--- a/cadc-java/Dockerfile
+++ b/cadc-java/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:34
+FROM fedora:37
 
 # MAINTAINER deprecated but upstream fedora image still has it
 LABEL org.opencontainers.image.authors="pdowler.cadc@gmail.com" \
@@ -11,7 +11,7 @@ RUN groupadd --gid 8675309 opencadc \
         --no-create-home --no-user-group --no-log-init opencadc
 
 # install required software
-RUN dnf install -y java-11-openjdk-headless.x86_64 ca-certificates sudo which procps-ng \
+RUN dnf install -y java-11-openjdk-headless.x86_64 ca-certificates sudo which curl \
     && dnf clean all
 
 # system settings and permissions

--- a/cadc-java/Dockerfile
+++ b/cadc-java/Dockerfile
@@ -11,7 +11,10 @@ RUN groupadd --gid 8675309 opencadc \
         --no-create-home --no-user-group --no-log-init opencadc
 
 # install required software
-RUN dnf install -y java-11-openjdk-headless.x86_64 ca-certificates sudo which curl \
+# install open source astronomy libraries needed by opencadc JNI libs
+# install minimal set of diagnostics tools: mainly for network connectivity
+RUN dnf install -y java-11-openjdk-headless.x86_64 ca-certificates sudo which \
+    && dnf install -y wcslib erfa curl openssl nmap-ncat \
     && dnf clean all
 
 # system settings and permissions

--- a/cadc-java/README.md
+++ b/cadc-java/README.md
@@ -3,7 +3,7 @@
 Base image with Java (currently 8) intended for Java applications. The goal is for child 
 images to simply add the application code and leave the rest to runtime deployment.
 
-Child images should use the  Dockerfile CMD option to specify the startup command. This allows
+Child images should use the  Dockerfile `CMD` option to specify the startup command. This allows
 the ENTRYPOINT script specified here to run and initialise the environment before starting the
 application.
 
@@ -11,12 +11,11 @@ application.
 
 Runtime configuration is found in /config and includes the following:
 
-### cadcproxy.pem
+### client proxy certificates (pem)
 
-This optional certificate is used to use to make remote calls that requrie a client certificate.
-
-TBD: this is questionable since this is a credential and not configuration per se and it probably expires 
-during the lifetime of the container.
+All `pem` files found in the /config directory are made available to applications in $HOME/.ssl/.
+Application code that uses client certificate(s) should load client certificates from $HOME/.ssl/;
+this is the case for all OpenCADC java applications.
 
 ### cacerts
 
@@ -27,6 +26,16 @@ This optional directory includes CA certificates (pem format) that are added to 
 The container includes an unprivileged user and group (opencadc) and the uid:gid in the container are an
 arbitrary high number (8675309); this allows one to grant permissions if an external volume/filesystem 
 is attached at runtime.
+
+## additional linux packages
+
+This image is based on Fedora Linux, so additional linux packages should be installed using the `dnf` command.
+Packages that are included: ca-certificates sudo (for CA cert setup), which (gradle appplication support),
+and curl (for manual diagnostics).
+
+Packages that are known to be added by some downstream OpenCADC image builds: wcslib.x86_64, erfa.x86_64. 
+TBD: include this small set of libs in the base image? Reason: avoid downstream install causing untested 
+upgrades in other packages.
 
 ## building it
 ```
@@ -49,11 +58,3 @@ docker build -t cadc-java-test -f Dockerfile.test .
 docker run -it --rm --user opencadc:opencadc --volume=/path/to/config:/config:ro cadc-java-test:latest
 ```
 
-## apply version tags
-```bash
-. VERSION && echo "tags: $TAGS" 
-for t in $TAGS; do
-   docker image tag cadc-java:latest cadc-java:$t
-done
-unset TAGS
-```

--- a/cadc-java/VERSION
+++ b/cadc-java/VERSION
@@ -1,4 +1,5 @@
 # semantic version tags for base containers: major major.minor
 # 1.1 : fedora 30, openjdk-1.8
 # 1.2 : fedora 34, java-11-openjdk
-TAGS="1 1.2"
+# 1.3 : fedora 37, java-11-openjdk
+TAGS="1 1.3"

--- a/cadc-java/src/cadc-java-init
+++ b/cadc-java/src/cadc-java-init
@@ -16,12 +16,12 @@ if [ -e $CONFDIR/cacerts ]; then
     sudo update-ca-trust
 fi
 
-if [ -f $CONFDIR/cadcproxy.pem ]; then
-    echo "Link proxy certificate: $CONFDIR/cadcproxy.pem"
+for pcf in $CONFDIR/*.pem; do
+    echo "Link proxy certificate: $pcf"
     mkdir -p $HOME/.ssl
     chmod 700 $HOME/.ssl
     ln -s $CONFDIR/cadcproxy.pem $HOME/.ssl/
-fi
+done
 
 test -e /config && (test -e $HOME/config || ln -s /config $HOME/config)
 

--- a/cadc-tomcat/Dockerfile
+++ b/cadc-tomcat/Dockerfile
@@ -12,8 +12,10 @@ RUN groupadd --gid 8675309 tomcat \
 
 # install required software
 # install open source JDBC driver(s)
+# install open source astronomy libraries needed by opencadc JNI libs
+# install minimal set of diagnostics tools: mainly for network connectivity
 RUN dnf install -y java-11-openjdk-headless.x86_64 tomcat.noarch ca-certificates sudo \
-    && dnf install -y postgresql-jdbc \ 
+    && dnf install -y postgresql-jdbc wcslib erfa curl openssl nmap-ncat \
     && dnf clean all
 
 # link jdbc driver(s) into tomcat lib

--- a/cadc-tomcat/Dockerfile
+++ b/cadc-tomcat/Dockerfile
@@ -16,6 +16,7 @@ RUN groupadd --gid 8675309 tomcat \
 # install minimal set of diagnostics tools: mainly for network connectivity
 RUN dnf install -y java-11-openjdk-headless.x86_64 tomcat.noarch ca-certificates sudo \
     && dnf install -y postgresql-jdbc wcslib erfa curl openssl nmap-ncat \
+    && rpm -e --nodeps java-17-openjdk-headless.x86_64 \
     && dnf clean all
 
 # link jdbc driver(s) into tomcat lib

--- a/cadc-tomcat/Dockerfile
+++ b/cadc-tomcat/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:34
+FROM fedora:37
 
 # MAINTAINER deprecated but upstream fedora image still has it
 LABEL org.opencontainers.image.authors="pdowler.cadc@gmail.com" \

--- a/cadc-tomcat/README.md
+++ b/cadc-tomcat/README.md
@@ -105,7 +105,9 @@ DOCKER_CONTENT_TRUST=1 docker build -t cadc-tomcat -f Dockerfile .
 
 ## checking it
 ```
-docker run --rm --user tomcat:tomcat -it --rm cadc-tomcat:latest /bin/bash
+docker run --rm -it --user tomcat:tomcat cadc-tomcat:latest /bin/bash
+
+docker run --rm -it cadc-tomcat:latest /bin/bash
 ```
 
 ## running it

--- a/cadc-tomcat/README.md
+++ b/cadc-tomcat/README.md
@@ -1,6 +1,6 @@
 # base cadc-tomcat image
 
-Base image with Java (currently 8) and Tomcat (9) intended for deploying web services. The goal is for child 
+Base image with Java (currently 11) and Tomcat (9) intended for deploying web services. The goal is for child 
 images to simply add a war file to /usr/share/tomcat/webapps and leave the rest to runtime deployment. This 
 image can be run as the user "tomcat" (see below).
 
@@ -41,21 +41,16 @@ tomcat.connector.proxyPort=443
 ```
 
 The _tomcat.connector properties_ are a subset of the 
-<a href="https://tomcat.apache.org/tomcat-9.0-doc/config/http.html">complete set of configuration options</a> for Tomcat Connector. Other
-configuration settings are either hard coded or left at the default value. The _secure_, _scheme_, _proxyName_, and _proxyPort_ are the values of the SSL_terminating proxy server that sits in front of the container. 
-They are used so applications see these values in the request URI (instead of the values for the container) and enable applications to generate 
-correct externally usable URLs to othe resources in the applicaiton. This generally removes the need for the proxy to examine and rewrite 
-out-going content (headers and body).
+<a href="https://tomcat.apache.org/tomcat-9.0-doc/config/http.html">complete set of 
+configuration options</a> for Tomcat Connector. Other configuration settings are either 
+hard coded or left at the default value. The _secure_, _scheme_, _proxyName_, and 
+_proxyPort_ are the values of the SSL_terminating proxy server that sits in front of 
+the container. They are used so applications see these values in the request URI 
+(instead of the values for the container) and enable applications to generate correct 
+externally usable URLs to othe resources in the applicaiton. This generally removes 
+the need for the proxy to examine and rewrite out-going content (headers and body).
 
 Additional system properties to configure the application can also be added here.
-
-For example, if 
-* the SSL termination accepts client certificates and forwards them via the X-Client-Certificate http header, and
-* your web application is built on OpenCADC java libraries, and 
-* you want to allow your web application to trust that header in any connection
-then you need to set `ca.nrc.cadc.auth.PrincipalExtractor.enableClientCertHeader = true`. WARNING: setting this
-property opens up a big security hole (clients can easily pass in a certificate and impersonate another user)
-so the tomcat containers *must* not be accessible to any untrusted clients.
 
 ### war-rename.conf
 This optional file contains directives to rename a war file in the webapps directory before
@@ -67,8 +62,8 @@ Note: applications have to be carefully written to never hard code path informat
 discover it from the request for this to work. Some applications may not be _movable_.
 
 Renaming the war file can take advantage of some tomcat war file naming conventions
-(https://tomcat.apache.org/tomcat-9.0-doc/config/context.html), for example: to rename the context or
-introduce additional path elements. 
+(https://tomcat.apache.org/tomcat-9.0-doc/config/context.html), for example: to rename 
+the context or introduce additional path elements.
 
 ### tomcat.conf
 This optional file contains configuration used by the tomcat startup, e.g.:
@@ -76,26 +71,32 @@ This optional file contains configuration used by the tomcat startup, e.g.:
 ```
 JAVA_OPTS=" {options added during tomcat startup} $JAVA_OPTS"
 ```
-Note: the default JAVA_OPTS include setting max stack space and max heap size to sensible limits 
-(currently 512MiB and 2GiB respectively).
+Note: the default JAVA_OPTS include setting max stack space and max heap size to 
+sensible limits (currently 512MiB and 2GiB respectively).
 
-### Client certificates 
-Zero or more client certificate(s) may be included in the config directory and are made available as `{user.home}/.ssl/{cert filename}` for use by the application (typically: server-to-server calls for A&A support). Client certificate files must have a `.pem` extension.
+### client certificates 
+Zero or more client certificate(s) may be included in the config directory and are 
+made available as `{user.home}/.ssl/{cert filename}` for use by the application (typically: 
+server-to-server calls for A&A support). Client certificate files must have a `.pem` extension.
 
-TBD: this is questionable since this is a credential and not configuration per se and it probably expires 
-during the lifetime of the container.
+TBD: this is questionable since this is a credential and not configuration per se and it 
+probably expires during the lifetime of the container.
 
 ### cacerts
-This optional directory includes CA certificates (pem format) that are added to the system trust store.
+This optional directory includes CA certificates (pem format) that are added to the 
+system trust store.
 
-## lib
-This optional directory includes java libraries (jar files) that are added to the tomcat system classpath.
-This can be used to include java libraries that are only known at config/deployment time but needed by 
-tomcat (e.g. a JDBC driver for a connection pool declared in the context.xml file).
+## additional linux packages
 
-TBD: the postgresql-jdbc driver is already included in the image and it may be feasible to add other open source drivers as needed.
+This image is based on Fedora Linux, so additional linux packages should be installed using the `dnf` command.
+Packages that are included: ca-certificates, sudo (for CA cert setup), and curl (for manual diagnostics). In
+addition, the PostgreSQL JDBC driver (postgresql-jdbc) is installed and symlinked into the tomcat
+server classpath and can be used in a a connection pool declared in the context.xml file). Other open source
+JDBC drivers could be included (TBD).
 
-TBD: this approach is questionable since this is software and not configuration per se.
+Packages that are known to be added by some downstream OpenCADC image builds: wcslib.x86_64, erfa.x86_64.
+TBD: include this small set of libs in the base image? Reason: avoid downstream install causing untested 
+upgrades in other packages.
 
 ## building it
 ```
@@ -104,25 +105,17 @@ DOCKER_CONTENT_TRUST=1 docker build -t cadc-tomcat -f Dockerfile .
 
 ## checking it
 ```
-docker run --user tomcat:tomcat -it --rm cadc-tomcat:latest /bin/bash
+docker run --rm --user tomcat:tomcat -it --rm cadc-tomcat:latest /bin/bash
 ```
 
 ## running it
 ```
-docker run --user tomcat:tomcat --volume=/path/to/config:/config:ro cadc-tomcat:latest
+docker run -rm --user tomcat:tomcat --volume=/path/to/config:/config:ro cadc-tomcat:latest
 ```
 
-The tomcat uid:gid in the container are an arbitrary high number (8675309); this allows one to grant permissions 
-if an external volume/filesystem is attached at runtime. 
+The tomcat uid:gid in the container are an arbitrary high number (8675309); this allows one 
+to grant permissions in external volume/filesystem(s) if attached at runtime.
 
 One can expose the tomcat port (-p {external http port}:8080) or use a proxy on the same host to access it via 
 the private IP address. 
 
-## apply version tags
-```bash
-. VERSION && echo "tags: $TAGS" 
-for t in $TAGS; do
-   docker image tag cadc-tomcat:latest cadc-tomcat:$t
-done
-unset TAGS
-```

--- a/cadc-tomcat/VERSION
+++ b/cadc-tomcat/VERSION
@@ -1,4 +1,5 @@
 # semantic version tags for base containers: major major.minor
 # 1.0 : fedora 30, openjdk-1.8, tomcat-9
-# 1.1 : fedora 34, java-11-openjdk, tomcat-9, postgresql-jdbc-42
-TAGS="1 1.1"
+# 1.1 : fedora 34, java-11-openjdk-headless, tomcat-9, postgresql-jdbc-42
+# 1.2 : fedora 37, java-11-openjdk-headless, tomcat-9, postgresql-jdbc-42
+TAGS="1 1.2"

--- a/cadc-tomcat/src/cadc-tomcat-start
+++ b/cadc-tomcat/src/cadc-tomcat-start
@@ -39,23 +39,12 @@ if [ -e $CONFDIR/cacerts ]; then
     sudo update-ca-trust
 fi
 
-if [ -e $CONFDIR/lib ]; then
-    echo "Add extra jars to tomcat classpath: $CONFDIR/lib"
-    cp $CONFDIR/lib/* /usr/share/tomcat/lib/
-fi
-
 for pcf in $CONFDIR/*.pem; do
     echo "Link proxy certificate: $pcf"
     mkdir $HOME/.ssl
     chmod 700 $HOME/.ssl
     ln -s $pcf $HOME/.ssl/
 done
-
-## brutal CADC-spcific hack
-if [ -e $CONFDIR/dbrc ]; then
-    echo "Link dbrc file: $CONFDIR/dbrc"
-    ln -s $CONFDIR/dbrc /usr/share/tomcat/.dbrc
-fi
 
 ln -s /config $HOME/config
 


### PR DESCRIPTION
document package requirements
include native libs requried by opencadc JNI binding libs: erfa wcslib
include some net/ssl diagnostic tools: openssl, curl, ncat

known issue: fedora 37 has a dependency tomcat -> java-headless which only resolves to java17, so currently also installing java11 and manually removing java17