### PR TITLE
update base java images to fedora 40

### DIFF
--- a/cadc-java/Dockerfile
+++ b/cadc-java/Dockerfile
@@ -1,11 +1,9 @@
-FROM fedora:37
+FROM fedora:40
 
 # MAINTAINER deprecated but upstream fedora image still has it
-LABEL org.opencontainers.image.authors="pdowler.cadc@gmail.com" \
-	maintainer="pdowler.cadc@gmail.com"
+LABEL org.opencontainers.image.authors="pdowler.cadc@gmail.com" maintainer="pdowler.cadc@gmail.com"
 
-
-# create unpriviledged user:group with known uid:gid
+# create opencadc user:group with known uid:gid
 RUN groupadd --gid 8675309 opencadc \
     && useradd --uid 8675309 --home-dir / --shell /sbin/nologin \
         --no-create-home --no-user-group --no-log-init opencadc

--- a/cadc-java/README.md
+++ b/cadc-java/README.md
@@ -30,12 +30,12 @@ is attached at runtime.
 ## additional linux packages
 
 This image is based on Fedora Linux, so additional linux packages should be installed using the `dnf` command.
-Packages that are included: ca-certificates sudo (for CA cert setup), which (gradle appplication support),
-and curl (for manual diagnostics).
+Several fedora packages are installed in addition to OpenJDK; this reduces the need for downstream 
+image builds to install common packages.
 
-Packages that are known to be added by some downstream OpenCADC image builds: wcslib.x86_64, erfa.x86_64. 
-TBD: include this small set of libs in the base image? Reason: avoid downstream install causing untested 
-upgrades in other packages.
+Current extra packages: 
+* network diagnostic tools: curl, openssl, nmap-cat
+* astronomy libs: erfa, wcslib
 
 ## building it
 ```

--- a/cadc-java/VERSION
+++ b/cadc-java/VERSION
@@ -2,4 +2,5 @@
 # 1.1 : fedora 30, openjdk-1.8
 # 1.2 : fedora 34, java-11-openjdk
 # 1.3 : fedora 37, java-11-openjdk
-TAGS="1 1.3"
+# 1.4 : fedora 40, java-11-openjdk
+TAGS="1 1.4"

--- a/cadc-tomcat/Dockerfile
+++ b/cadc-tomcat/Dockerfile
@@ -1,22 +1,22 @@
 FROM fedora:40
 
 # MAINTAINER deprecated but upstream fedora image still has it
-LABEL org.opencontainers.image.authors="pdowler.cadc@gmail.com" \
-        maintainer="pdowler.cadc@gmail.com"
+LABEL org.opencontainers.image.authors="pdowler.cadc@gmail.com" maintainer="pdowler.cadc@gmail.com"
 
 # create tomcat user:group with known uid:gid
 RUN groupadd --gid 8675309 tomcat \
     && useradd --uid 8675309 --home-dir /usr/share/tomcat --shell /sbin/nologin \
         --no-create-home --no-user-group --no-log-init tomcat
 
-
 # install required software
 # install open source JDBC driver(s)
 # install open source astronomy libraries needed by opencadc JNI libs
 # install minimal set of diagnostics tools: mainly for network connectivity
-RUN dnf install -y java-21-openjdk-headless.x86_64 tomcat.noarch ca-certificates sudo \
+# remove java-21 (tomcat dependency)
+RUN dnf install -y java-11-openjdk-headless.x86_64 tomcat.noarch ca-certificates sudo which \
     && dnf install -y postgresql-jdbc \
     && dnf install -y wcslib erfa curl openssl nmap-ncat \
+    && rpm -v --erase --nodeps java-21-openjdk-headless \
     && dnf clean all
 
 # link jdbc driver(s) into tomcat lib

--- a/cadc-tomcat/README.md
+++ b/cadc-tomcat/README.md
@@ -89,14 +89,12 @@ system trust store.
 ## additional linux packages
 
 This image is based on Fedora Linux, so additional linux packages should be installed using the `dnf` command.
-Packages that are included: ca-certificates, sudo (for CA cert setup), and curl (for manual diagnostics). In
-addition, the PostgreSQL JDBC driver (postgresql-jdbc) is installed and symlinked into the tomcat
-server classpath and can be used in a a connection pool declared in the context.xml file). Other open source
-JDBC drivers could be included (TBD).
+Several fedora packages are installed in addition to OpenJDK and tomcat; this reduces the need for downstream 
+image builds to install common packages.
 
-Packages that are known to be added by some downstream OpenCADC image builds: wcslib.x86_64, erfa.x86_64.
-TBD: include this small set of libs in the base image? Reason: avoid downstream install causing untested 
-upgrades in other packages.
+Current extra packages: 
+* network diagnostic tools: curl, openssl, nmap-cat
+* astronomy libs: erfa, wcslib
 
 ## building it
 ```

--- a/cadc-tomcat/VERSION
+++ b/cadc-tomcat/VERSION
@@ -3,5 +3,5 @@
 # 1.1 : fedora 34, java-11-openjdk-headless, tomcat-9, postgresql-jdbc-42
 # 1.2 : fedora 37, java-11-openjdk-headless, tomcat-9, postgresql-jdbc-42
 # 1.2.1 : additional symlinks for postgresql-jdbc dependencies
-# 1.3 : fedora 40, java-17, tomcat-9, 
-TAGS="1 1.3 1.3.0"
+# 1.3 : fedora 40, java-11-openjdk-headless, tomcat-9, postgresql-jdbc-42
+TAGS="1 1.3"


### PR DESCRIPTION
still openjdk-11 and tomcat-9

wcslib-8 so code that uses this needs at least cadc-wcs-2.2.0