### PR TITLE
Add arm64 builds

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -6,21 +6,128 @@ on:
 
 jobs:
 
-  build:
-
-    runs-on: ubuntu-latest
+  get-build-time:
+    runs-on: "ubuntu-latest"
+    outputs:
+      seconds: ${{ steps.epoch.outputs.seconds }}
 
     steps:
-    - uses: actions/checkout@v1
-    
-    - name: Build cadc-java
-      run: cd cadc-java && DOCKER_CONTENT_TRUST=1 docker build . --file Dockerfile --tag cadc-tomcat:$(date +%s)
-    
-    - name: Build cadc-tomcat
-      run: cd cadc-tomcat && DOCKER_CONTENT_TRUST=1 docker build . --file Dockerfile --tag cadc-tomcat:$(date +%s)
-    
-    - name: Build cadc-postgresql-dev
-      run: cd cadc-postgresql-dev && DOCKER_CONTENT_TRUST=1 docker build . --file Dockerfile --tag cadc-postgresql-dev:$(date +%s)
-    
-    - name: Build cadc-haproxy-dev
-      run: cd cadc-haproxy-dev && DOCKER_CONTENT_TRUST=1 docker build . --file Dockerfile --tag cadc-haproxy-dev:$(date +%s)
+      - name: Get epoch seconds
+        id: epoch
+        run: |
+          s=$(date +%s)
+          echo "seconds=${s}" >> ${GITHUB_OUTPUT}
+ 
+  build:
+    needs: [get-build-time]
+    strategy:
+      matrix:
+        platform:
+          - arch: "arm64"
+            runs_on: "ubuntu-24.04-arm"
+          - arch: "amd64"
+            runs_on: "ubuntu-latest"
+        product:
+          - context: "cadc-java"
+          - context: "cadc-tomcat"
+          # - context: "cadc-postgresql-dev"  # Requires pgsphere rpm
+          # (no aarch64 RPM is currently built)
+          - context: "cadc-haproxy-dev"
+    runs-on: ${{ matrix.platform.runs_on }}
+    env:
+      tag: ${{ matrix.product.context == 'cadc-java' && 'cadc-tomcat' || matrix.product.context }}
+      DOCKER_CONTENT_TRUST: 1
+      seconds: ${{ needs.get-build-time.outputs.seconds }}
+
+    steps:
+    - name: Check out sources
+      uses: actions/checkout@v5
+
+    - name: Setup buildx
+      uses: docker/setup-buildx-action@v3
+      with:
+        name: builder-${{ matrix.platform.arch }}-${{ matrix.product.context }}
+        platforms: linux/${{ matrix.platform.arch }}
+
+    - name: Log in to ghcr.io
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build container
+      uses: docker/build-push-action@v6
+      with:
+        context: ${{ matrix.product.context }}
+        builder: builder-${{ matrix.platform.arch }}-${{ matrix.product.context }}
+        cache-from: "type=gha"
+        cache-to: "type=gha,mode=max"
+        # Change tags for CADC push target: this is for lsst-sqre
+        # Presumably images.opencadc.org/library/${{ matrix.product.context }}-${{ matrix.platform.arch }}:<version>
+        tags: ghcr.io/${{ github.repository }}-${{ matrix.product.context }}-${{ matrix.platform.arch }}:${{ env.seconds }}
+        push: true
+
+  unify:
+    needs: [get-build-time,build]
+    runs-on: ubuntu-latest
+    env:
+      seconds: ${{ needs.get-build-time.outputs.seconds }}
+    strategy:
+      matrix:
+        product:
+          - "cadc-java"
+          - "cadc-tomcat"
+          # - "cadc-postgresql-dev"  # Requires pgsphere RPM (no aarch64)
+          - "cadc-haproxy-dev"
+        
+    steps:
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Unify manifests
+        uses: Noelware/docker-manifest-action@v1
+        with:
+          inputs: ghcr.io/${{ github.repository }}-${{ matrix.product }}-amd64:${{ env.seconds }},ghcr.io/${{ github.repository }}-${{ matrix.product }}-arm64:${{ env.seconds }}
+          tags: ghcr.io/${{ github.repository }}-${{ matrix.product }}:${{ env.seconds }}
+
+  build-cadc-postgresql-dev:
+    # Once there is a pgsphere RPM for aarch64, we can reintegrate this
+    # into the matrix above.
+    needs: [get-build-time]
+    runs-on: ubuntu-latest
+    env:
+      seconds: ${{ needs.get-build-time.outputs.seconds }}
+
+    steps:
+      - name: Check out sources
+        uses: actions/checkout@v5
+
+      - name: Setup buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          name: builder-amd64-cadc-postgresql-dev
+          platforms: linux/amd64
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build container
+        uses: docker/build-push-action@v6
+        with:
+          context: cadc-postgresql-dev
+          builder: builder-amd64-cadc-postgresql-dev
+          cache-from: "type=gha"
+          cache-to: "type=gha,mode=max"
+          # Change tags for CADC push target: this is for lsst-sqre
+          # Presumably images.opencadc.org/library/cadc-postgresql-dev:<version>
+          tags: ghcr.io/${{ github.repository }}-cadc-postgresql-dev:${{ env.seconds }}
+          push: true

--- a/cadc-postgresql-dev/Dockerfile
+++ b/cadc-postgresql-dev/Dockerfile
@@ -9,6 +9,8 @@ ARG PGSERVER="postgresql15-server postgresql15-contrib"
 ARG PGSPHERE=https://ws-cadc.canfar.net/vault/files/pdowler/rpms/pgsphere15-1.4.2-1.fc42.x86_64.rpm
 
 # install repositories, server, extensions
+# But first create /var/lib/pgsql because ${PGDG} expects it to exist.
+RUN mkdir -p /var/lib/pgsql && chown 26:26 /var/lib/pgsql
 RUN dnf -y install ${PGDG} \
     && dnf -y install ${PGSERVER} ${PGSPHERE} \
     && dnf -y clean all


### PR DESCRIPTION
Except for cadc-postgresql-dev, which would require an aarch64 pgsphere RPM (and ideally a fedora 42 PG 15 aarch RPM).

I also slightly tweaked the Dockerfile for cadc-postgresql-dev, because an install script for the repo expected /var/lib/pgsql  to exist already.  This is probably better fixed with a `mkdir -p` inside that scriptlet than what I did.

Context: I work for Rubin Observatory, and we are investigating moving the Rubin Science Platform entirely to the arm64 architecture.  I'm ensuring I have containers for everything I need to do that.

Also note that this pushes to ghcr.io under docker-base-<name-of-product> and uses seconds-since-the-epoch for its tag; clearly CADC does not prepare its official releases via GitHub Action, but I don't know how any of that works, so...well, you could pull the image from ghcr.io, retag, and push, or you could rework the GHA to add a release tag and push to the correct destination, if you put a credential for that destination in your GitHub secrets.

That might be desirable, in that the matrix build strategy I'm using parallelizes a lot of stuff.  You could also just do `docker buildx build` with `--platform` but that will run your build stages for each architecture sequentially and all but one of your architectures (presumably, all but amd64) will be emulated under QEMU, and therefore will be a lot slower.  If you're only doing a handful of releases a year, you might not care about build speed.

Note also that this is pushing architecture-specific images to the repository and doing the fixup for a multiplatform manifest in a separate job.  This is not as bad as it seems, because for a multiplatform image, you're going to need all the layers from each image anyway.  Thus the actual overhead is only whatever the metadata for two more image names (...-amd64 and -arm64) is plus the unifying manifest (a couple of KB).

We're doing it that way at Rubin Observatory so we can take advantage of building arm64 natively and in parallel with amd64, and some of our images are too large to fit in the GitHub cache, so we need to push the images so we can do a HEAD to get a layer manifest out of them.